### PR TITLE
Don't teach "retired" spread & gather?

### DIFF
--- a/03-dplyr.Rmd
+++ b/03-dplyr.Rmd
@@ -21,9 +21,8 @@ surveys <- readr::read_csv("data_raw/portal_data_joined.csv")
 > * Add new columns to a data frame that are functions of existing columns with `mutate`.
 > * Use the split-apply-combine concept for data analysis.
 > * Use `summarize`, `group_by`, and `count` to split a data frame into groups of observations, apply summary statistics for each group, and then combine the results.
-> * Describe the concept of a wide and a long table format and for which purpose those formats are useful.
-> * Describe what key-value pairs are.
-> * Reshape a data frame from long to wide format and back with the `spread` and `gather` commands from the **`tidyr`** package.
+> * Describe the concept of a wider and a longer table format and for which purpose they are useful.
+> * Pivot a data frame between the two formats with the `pivot_wider` and `pivot_longer` commands from the **`tidyr`** package.
 > * Export a data frame to a .csv file.
 
 ------------
@@ -427,7 +426,7 @@ the *albigula* species that are not specified for its sex (i.e. `NA`).
 >     arrange(year)
 > ```
 
-### Reshaping with gather and spread
+### Pivoting
 
 In the [spreadsheet
 lesson](https://datacarpentry.org/spreadsheet-ecology-lesson/01-format-data/),
@@ -452,27 +451,26 @@ in `genus` would become the names of column variables and the cells would contai
 Having created a new table, it is therefore straightforward to explore the 
 relationship between the weight of different genera within, and between, the
 plots. The key point here is that we are still following a tidy data structure,
-but we have **reshaped** the data according to the observations of interest:
+but we have **pivoted** the data according to the observations of interest:
 average genus weight per plot instead of recordings per date.
 
-The opposite transformation would be to transform column names into values of
-a variable.
+The opposite transformation would be: column names into values of a variable.
 
-We can do both these of transformations with two `tidyr` functions, `spread()`
-and `gather()`.
+We can do both these of transformations with two `tidyr` functions, `pivot_wider()`
+and `pivot_longer()`.
 
-#### Spreading
+#### Pivoting the dataset wider
 
-`spread()` takes three principal arguments:
+`pivot_wider()` takes three principal arguments:
 
 1. the data 
-2. the *key* column variable whose values will become new column names.  
-3. the *value* column variable whose values will fill the new column variables.
+2. the *names_from* column variable whose values will become new column names.  
+3. the *values_from* column variable whose values will fill the new column variables.
 
 Further arguments include `fill` which, if set, fills in missing values with 
 the value provided.
 
-Let's use `spread()` to transform `surveys` to find the mean weight of each 
+Let's use `pivot_wider()` to transform `surveys` to find the mean weight of each 
 genus in each plot over the entire survey period. We use `filter()`,
 `group_by()` and `summarise()` to filter our observations and variables of 
 interest, and create a new variable for the `mean_weight`.
@@ -488,68 +486,60 @@ head(surveys_gw, n = 10)
 
 This yields `surveys_gw` where the observations for each plot are spread across
 multiple rows, 196 observations of 3 variables. 
-Using `spread()` to key on `genus` with values from `mean_weight` this becomes
+Using `pivot_wider()` with names from `genus` and values from `mean_weight`, this becomes
 24 observations of 11 variables, one row for each plot.
 
 ```{r}
-(surveys_spread <- spread(surveys_gw, key = genus, value = mean_weight))
+(surveys_wider <- pivot_wider(surveys_gw, names_from = genus, values_from = mean_weight))
 ```
 
 ![](img/spread_data_R.png)
 
-We could now plot comparisons between the weight of genera in different plots, 
-although we may wish to fill in the missing values first.
 
-```{r}
-spread(surveys_gw, genus, mean_weight, fill = 0)
-```
-
-#### Gathering
+#### Pivoting the dataset longer
 
 The opposing situation could occur if we had been provided with data in the
-form of `surveys_spread`, where the genus names are column names, but we 
+form of `surveys_wider`, where the genus names are column names, but we 
 wish to treat them as values of a genus variable instead.
 
-In this situation we are gathering the column names and turning them into a
-pair of new variables. One variable represents the column names as values, and
-the other variable contains the values previously associated with the column names.
+In this situation we are pivoting the columns and turning them into a
+pair of new variables.
 
-`gather()` takes four principal arguments:
+`pivot_longer()` takes four principal arguments:
 
 1. the data
-2. the *key* column variable we wish to create from column names.
-3. the *values* column variable we wish to create and fill with values 
-associated with the key.
-4. the names of the columns we use to fill the key variable (or to drop).
+1. the names of the columns we use to fill the new variables (or to drop).
+1. *names_to*: name of the new variable that receives the columns' names as values
+1. *values_to*: name of the new variable that receives the values from the previous columns.
 
-To recreate `surveys_gw` from `surveys_spread` we would create a key called
-`genus` and value called `mean_weight` and use all columns except `plot_id` for
-the key variable. Here we drop `plot_id` column with a minus sign.
+To recreate `surveys_gw` from `surveys_wider` we would create a variable called
+`genus` and one variable called `mean_weight` and use all columns except `plot_id`.
+Here we drop `plot_id` column with a minus sign.
 
 ```{r}
-surveys_gather <- gather(surveys_spread, key = "genus", value = "mean_weight", -plot_id)
+surveys_longer <- pivot_longer(surveys_wider, -plot_id, names_to = "genus", values_to = "mean_weight")
 
-str(surveys_gather)
+str(surveys_longer)
 ```
 
 ![](img/gather_data_R.png)
 
-Note that now the `NA` genera are included in the re-gathered format. Spreading
-and then gathering can be a useful way to balance out a dataset so every
+Note that now the `NA` genera are included in the pivoted format. Pivoting wider,
+then longer can be a useful way to balance out a dataset so every
 replicate has the same composition.
 
 We could also have used a specification for what columns to include. This can be
 useful if you have a large number of identifying columns, and it's easier to
-specify what to gather than what to leave alone. And if the columns are directly
+specify what to pivot than what to leave alone. And if the columns are directly
 adjacent, we don't even need to list them all out - just use the `:` operator!
 
 ```{r}
-gather(surveys_spread, key = "genus", value = "mean_weight", Baiomys:Spermophilus)
+pivot_longer(surveys_wider, Baiomys:Spermophilus, "genus", "mean_weight")
 ```
 
 > ### Challenge {.challenge}
 >
-> 1. Spread the `surveys` data frame with `year` as columns, `plot_type` 
+> 1. Pivot the `surveys` data frame wider, with `year` as columns, `plot_type` 
 >   as rows, and the
 >   number of genera per plot as the values. You will need to summarize before
 >   reshaping, and use the function `n_distinct()` to get the number of unique
@@ -557,45 +547,45 @@ gather(surveys_spread, key = "genus", value = "mean_weight", Baiomys:Spermophilu
 >   `?n_distinct` for more.
 > 
 > ```{r, answer=TRUE}
-> surveys_spread_genera <- surveys %>%
+> surveys_wider_genera <- surveys %>%
 >   group_by(plot_type, year) %>%
 >   summarize(n_genera = n_distinct(genus)) %>%
->   spread(year, n_genera)
+>   pivot_wider(year, n_genera)
 > 
-> head(surveys_spread_genera)
+> head(surveys_wider_genera)
 > ```
 >
-> 2. Now take that data frame and `gather()` it again, so each row is a unique
+> 2. Now take that data frame and `pivot_longer()` it again, so each row is a unique
 >    `plot_type` by `year` combination.
 >
 > ```{r, answer=TRUE}
-> gather(surveys_spread_genera, "year", "n_genera", -plot_type)
+> pivot_longer(surveys_wider_genera, -plot_type, "year", "n_genera")
 > ```
 >
 > 3. The `surveys` data set has
 >    two measurement columns: `hindfoot_length` and `weight`.  This makes it
 >    difficult to do things like look at the relationship between mean values of
 >    each measurement per year in different plot types. Let's walk through a
->    common solution for this type of problem. First, use `gather()` to create a
->     dataset where we have a key column called `measurement` and a
->    `value` column that takes on the value of either `hindfoot_length` or
->    `weight`. *Hint*: You'll need to specify which columns are being gathered.
+>    common solution for this type of problem. First, use `pivot_longer()` to create a
+>     dataset where we have a variable called `measurement` and a
+>    `value` variable that takes on the value of either `hindfoot_length` or
+>    `weight`. *Hint*: You'll need to specify which columns are being pivoted.
 >
 > ```{r, answer=TRUE}
-> surveys_long <- gather(surveys, "measurement", "value", hindfoot_length, weight)
+> surveys_longer <- pivot_longer(surveys, cols = c(hindfoot_length, weight), names_to = "measurement", values_to  = "value")
 > ```
 >
 > 4. With this new data set, calculate the average of each
 >    `measurement` in each `year` for each different `plot_type`. Then
->    `spread()` them into a data set with a column for `hindfoot_length` and
+>    `pivot_wider()` them into a data set with a column for `hindfoot_length` and
 >    `weight`. *Hint*: You only need to specify the key and value
->    columns for `spread()`.
+>    columns for `pivot_wider()`.
 >
 > ```{r, answer=TRUE}
-> surveys_long %>%
+> surveys_longer %>%
 >   group_by(year, measurement, plot_type) %>%
 >   summarize(mean_value = mean(value, na.rm=TRUE)) %>%
->   spread(measurement, mean_value)
+>   pivot_wider(names_from = measurement, values_from = mean_value)
 > ```
 
 # Exporting data

--- a/05-knitr-markdown.Rmd
+++ b/05-knitr-markdown.Rmd
@@ -173,7 +173,7 @@ The Markdown and figure documents are then processed by the tool
 [`pandoc`](https://pandoc.org/), which compiles the Markdown file into an
 another document format, with the figures, tables, etc. embedded.
 
-In the previous lessons, we used `spread()` to transform `surveys` to find the
+In the previous lessons, we used `pivot_wider()` to transform `surveys` to find the
 mean weight of each genus in each plot over the entire survey period. The resulting
 table can be output into our document with `knitr`'s `kable()` function:
 
@@ -185,7 +185,7 @@ read_csv("data_raw/portal_data_joined.csv") %>%
   filter(!is.na(weight)) %>%
   group_by(plot_type, genus) %>%
   summarize(mean_weight = round(mean(weight), 1)) %>%
-  spread(key = genus, value = mean_weight) %>% 
+  pivot_wider(names_from = genus, values_from = mean_weight) %>% 
   kable()
 &#96;&#96;&#96;
 </pre>
@@ -197,7 +197,7 @@ read_csv("data/surveys_complete.csv") %>%
   filter(!is.na(weight)) %>%
   group_by(plot_type, genus) %>%
   summarize(mean_weight = round(mean(weight), 1)) %>%
-  spread(key = genus, value = mean_weight) %>% 
+  pivot_wider(names_from = genus, values_from = mean_weight) %>% 
   kable()
 ```
 


### PR DESCRIPTION
I noticed https://github.com/datacarpentry/r-socialsci/issues/104 & https://tidyr.tidyverse.org/news/index.html#pivoting only yesterday. That seems very unfortunate to me:

1. either we don't mention this in the workshop (don't show `gather` & `spread` docu), or
1. we teach the apparently new standard on short notice,
1. or we rely on the [official vignette](https://tidyr.tidyverse.org/articles/pivot.html)

1 seems a bit negligent to me, but 2. could be too hasty, while 3. leads off-script & off-data.

I've practices both 1 & 2 a bit, but have not updated info-graphics so far.